### PR TITLE
Rustup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+rust: nightly
 script:
   - cargo test
   - cargo doc

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -11,6 +11,9 @@ build = "build.rs"
 name = "tendril_capi"
 crate-type = ["staticlib"]
 
+[dependencies]
+libc = "0.1"
+
 [dependencies.tendril]
 path = "../"
 

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -4,14 +4,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(core, libc)]
 #![warn(warnings)]
 
 extern crate libc;
 extern crate tendril;
 
 use tendril::{ByteTendril, StrTendril};
-use std::{mem, raw};
+use std::slice;
 
 // Link the C glue code
 #[link_name="tendril_cglue"]
@@ -42,11 +41,7 @@ fn tendril_clear(t: *mut ByteTendril) {
 
 #[no_mangle] pub unsafe extern "C"
 fn tendril_push_buffer(t: *mut ByteTendril, buffer: *const u8, length: u32) {
-    let s = raw::Slice {
-        data: buffer,
-        len: length as usize,
-    };
-    (*t).push_slice(mem::transmute(s));
+    (*t).push_slice(slice::from_raw_parts(buffer, length as usize));
 }
 
 #[no_mangle] pub unsafe extern "C"

--- a/src/buf32.rs
+++ b/src/buf32.rs
@@ -6,7 +6,7 @@
 
 //! Provides an unsafe owned buffer type, used in implementing `Tendril`.
 
-use std::{raw, mem, ptr, cmp, u32};
+use std::{mem, ptr, cmp, u32, slice};
 use std::rt::heap;
 
 use OFLOW;
@@ -76,21 +76,13 @@ impl<H> Buf32<H> {
     }
 
     #[inline(always)]
-    pub unsafe fn data_raw(&self) -> raw::Slice<u8> {
-        raw::Slice {
-            data: self.data_ptr(),
-            len: self.len as usize,
-        }
-    }
-
-    #[inline(always)]
     pub unsafe fn data(&self) -> &[u8] {
-        mem::transmute(self.data_raw())
+        slice::from_raw_parts(self.data_ptr(), self.len as usize)
     }
 
     #[inline(always)]
     pub unsafe fn data_mut(&mut self) -> &mut [u8] {
-        mem::transmute(self.data_raw())
+        slice::from_raw_parts_mut(self.data_ptr(), self.len as usize)
     }
 
     /// Grow the capacity to at least `new_cap`.
@@ -129,8 +121,7 @@ mod test {
             assert_eq!(b"", b.data());
 
             b.grow(5);
-            intrinsics::copy_nonoverlapping(b"Hello".as_ptr(),
-                b.data_raw().data as *mut u8, 5);
+            intrinsics::copy_nonoverlapping(b"Hello".as_ptr(), b.data_ptr(), 5);
 
             assert_eq!(b"", b.data());
             b.len = 5;

--- a/src/buf32.rs
+++ b/src/buf32.rs
@@ -88,6 +88,11 @@ impl<H> Buf32<H> {
         mem::transmute(self.data_raw())
     }
 
+    #[inline(always)]
+    pub unsafe fn data_mut(&mut self) -> &mut [u8] {
+        mem::transmute(self.data_raw())
+    }
+
     /// Grow the capacity to at least `new_cap`.
     ///
     /// This will panic if the capacity calculation overflows `u32`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,7 @@
 // except according to those terms.
 
 use std::{slice, intrinsics};
+use std::mem;
 use std::raw::{self, Repr};
 
 #[inline(always)]
@@ -16,7 +17,22 @@ pub unsafe fn unsafe_slice<'a>(buf: &'a [u8], start: usize, new_len: usize) -> &
 }
 
 #[inline(always)]
+pub unsafe fn unsafe_slice_mut<'a>(buf: &'a mut [u8], start: usize, new_len: usize) -> &'a mut [u8] {
+    let raw::Slice { data, len } = buf.repr();
+    debug_assert!(start <= len);
+    debug_assert!(new_len <= (len - start));
+    slice::from_raw_parts_mut((data as *mut u8).offset(start as isize), new_len)
+}
+
+#[inline(always)]
 pub unsafe fn copy_and_advance(dest: &mut *mut u8, src: &[u8]) {
     intrinsics::copy_nonoverlapping(src.as_ptr(), *dest, src.len());
     *dest = dest.offset(src.len() as isize)
 }
+
+#[inline(always)]
+pub unsafe fn copy_lifetime_mut<'a, S: ?Sized, T: ?Sized + 'a>
+                           (_ptr: &'a mut S, ptr: &mut T) -> &'a mut T {
+    mem::transmute(ptr)
+}
+

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,22 +6,19 @@
 
 use std::{slice, intrinsics};
 use std::mem;
-use std::raw::{self, Repr};
 
 #[inline(always)]
 pub unsafe fn unsafe_slice<'a>(buf: &'a [u8], start: usize, new_len: usize) -> &'a [u8] {
-    let raw::Slice { data, len } = buf.repr();
-    debug_assert!(start <= len);
-    debug_assert!(new_len <= (len - start));
-    slice::from_raw_parts(data.offset(start as isize), new_len)
+    debug_assert!(start <= buf.len());
+    debug_assert!(new_len <= (buf.len() - start));
+    slice::from_raw_parts(buf.as_ptr().offset(start as isize), new_len)
 }
 
 #[inline(always)]
 pub unsafe fn unsafe_slice_mut<'a>(buf: &'a mut [u8], start: usize, new_len: usize) -> &'a mut [u8] {
-    let raw::Slice { data, len } = buf.repr();
-    debug_assert!(start <= len);
-    debug_assert!(new_len <= (len - start));
-    slice::from_raw_parts_mut((data as *mut u8).offset(start as isize), new_len)
+    debug_assert!(start <= buf.len());
+    debug_assert!(new_len <= (buf.len() - start));
+    slice::from_raw_parts_mut(buf.as_mut_ptr().offset(start as isize), new_len)
 }
 
 #[inline(always)]


### PR DESCRIPTION
`Tendril::as_byte_slice` is unchanged, but moved to be next to `Tendril<Bytes>::deref_mut` which is very similar.

r? @Ms2ger 

@metajack Could you set up homu on this repository?