### PR TITLE
impl Borrow<[u8]> for Tendril

### DIFF
--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 use std::{ptr, mem, intrinsics, hash, str, u32, io, slice, cmp};
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 use std::marker::PhantomData;
 use std::cell::Cell;
 use std::ops::{Deref, DerefMut};
@@ -161,6 +161,18 @@ impl<F> Deref for Tendril<F>
         }
     }
 }
+
+impl<F> Borrow<[u8]> for Tendril<F>
+    where F: fmt::SliceFormat,
+{
+    fn borrow(&self) -> &[u8] {
+        self.as_byte_slice()
+    }
+}
+
+// Why not impl Borrow<str> for Tendril<fmt::UTF8>? str and [u8] hash differently,
+// and so a HashMap<StrTendril, _> would silently break if we indexed by str. Ick.
+// https://github.com/rust-lang/rust/issues/27108
 
 impl<'a, F> Extend<&'a Tendril<F>> for Tendril<F>
     where F: fmt::Format + 'a,

--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -1726,4 +1726,21 @@ mod test {
         let long: Vec<u8> = iter::repeat(b'x').take(1_000_000).collect();
         check(&long);
     }
+
+    #[test]
+    fn hash_map_key() {
+        use std::collections::HashMap;
+
+        // As noted with Borrow, indexing on HashMap<StrTendril, _> is byte-based because of
+        // https://github.com/rust-lang/rust/issues/27108.
+        let mut map = HashMap::new();
+        map.insert("foo".to_tendril(), 1);
+        assert_eq!(map.get(b"foo" as &[u8]), Some(&1));
+        assert_eq!(map.get(b"bar" as &[u8]), None);
+
+        let mut map = HashMap::new();
+        map.insert(b"foo".to_tendril(), 1);
+        assert_eq!(map.get(b"foo" as &[u8]), Some(&1));
+        assert_eq!(map.get(b"bar" as &[u8]), None);
+    }
 }


### PR DESCRIPTION
This makes using a Tendril as a HashMap key a little more palatable. Sadly, `str` and `[u8]` hash differently at present, so we shouldn’t implement `Borrow<str>` for `StrTendril`. An alternative would be making the `Hash` implementations for `Tendril<F>` manual and making `Tendril<UTF8>` use the `str` `Hash` implementation and the rest use the `[u8]` one.

See also https://github.com/rust-lang/rust/issues/27108 which deals with fixing the underlying problem of the differing `Hash` implementations.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/tendril/13)
<!-- Reviewable:end -->
