### PR TITLE
Run on stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ script:
   - cargo build
   - cargo doc
   - cargo test
-  - "(cd capi/ctest; ./build-and-test.sh)"
+  - "if [ $TRAVIS_RUST_VERSION = nightly ]; then cargo test --features unstable; fi"
+  - "if [ $TRAVIS_RUST_VERSION = nightly ]; then (cd capi/ctest; ./build-and-test.sh); fi"
 after_success: curl https://raw.githubusercontent.com/kmcallister/travis-doc-upload/master/travis-doc-upload.sh | sh
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ rust:
 script:
   - cargo build
   - cargo doc
-  - "if [ $TRAVIS_RUST_VERSION = nightly ]; then cargo test; fi"
-  - "if [ $TRAVIS_RUST_VERSION = nightly ]; then (cd capi/ctest; ./build-and-test.sh); fi"
+  - cargo test
+  - "(cd capi/ctest; ./build-and-test.sh)"
 after_success: curl https://raw.githubusercontent.com/kmcallister/travis-doc-upload/master/travis-doc-upload.sh | sh
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: rust
-rust: nightly
+rust:
+  - nightly
+  - beta
+  - stable
 script:
-  - cargo test
+  - cargo build
   - cargo doc
-  - (cd capi/ctest; ./build-and-test.sh)
+  - "if [ $TRAVIS_RUST_VERSION = nightly ]; then cargo test; fi"
+  - "if [ $TRAVIS_RUST_VERSION = nightly ]; then (cd capi/ctest; ./build-and-test.sh); fi"
 after_success: curl https://raw.githubusercontent.com/kmcallister/travis-doc-upload/master/travis-doc-upload.sh | sh
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "tendril"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Keegan McAllister <mcallister.keegan@gmail.com>"]
 repository = "https://github.com/kmcallister/tendril"
 readme = "README.md"
@@ -11,7 +11,10 @@ description = "compact buffer / string type for zero-copy parsing"
 [dependencies]
 mac = "0"
 encoding = "0"
-futf = "0.1"
+futf = "0.1.1"
 
 [dev-dependencies]
 rand = "0"
+
+[features]
+unstable = []

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -16,6 +16,7 @@ libc = "0.1"
 
 [dependencies.tendril]
 path = "../"
+features = ["unstable"]  # Drop flags and C API don’t play friends
 
 [build-dependencies]
 gcc = "0"

--- a/examples/fuzz.rs
+++ b/examples/fuzz.rs
@@ -6,7 +6,6 @@
 
 //! A simple fuzz tester for the library.
 
-#![feature(unsafe_no_drop_flag, str_char)]
 #![deny(warnings)]
 
 extern crate rand;
@@ -106,7 +105,7 @@ fn fuzz() {
 fn random_boundary<R: Rng>(rng: &mut R, text: &str) -> usize {
     loop {
         let i = Range::new(0, text.len()+1).ind_sample(rng);
-        if text.is_char_boundary(i) {
+        if is_char_boundary(text, i) {
             return i;
         }
     }
@@ -116,13 +115,22 @@ fn random_slice<R: Rng>(rng: &mut R, text: &str) -> (usize, usize) {
     loop {
         let start = Range::new(0, text.len()+1).ind_sample(rng);
         let end = Range::new(start, text.len()+1).ind_sample(rng);
-        if !text.is_char_boundary(start) {
+        if !is_char_boundary(text, start) {
             continue;
         }
-        if end < text.len() && !text.is_char_boundary(end) {
+        if end < text.len() && !is_char_boundary(text, end) {
             continue;
         }
         return (start, end);
+    }
+}
+
+// Copy of the str::is_char_boundary method, which is unstable.
+fn is_char_boundary(s: &str, index: usize) -> bool {
+    if index == s.len() { return true; }
+    match s.as_bytes().get(index) {
+        None => false,
+        Some(&b) => b < 128 || b >= 192,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(alloc, core, unsafe_no_drop_flag, filling_drop, unicode, ref_slice, nonzero, heap_api, oom)]
+#![feature(alloc, core, unsafe_no_drop_flag, filling_drop, nonzero, heap_api, oom)]
 #![cfg_attr(test, feature(test, str_char))]
 #![deny(warnings)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(core, unsafe_no_drop_flag, filling_drop, nonzero)]
+#![cfg_attr(feature = "unstable", feature(core, nonzero, unsafe_no_drop_flag, filling_drop))]
 #![cfg_attr(test, feature(test, str_char))]
 #![cfg_attr(test, deny(warnings))]
 
-extern crate core;
+#[cfg(feature = "unstable")] extern crate core;
 #[macro_use] extern crate mac;
 extern crate futf;
 extern crate encoding;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(alloc, core, unsafe_no_drop_flag, filling_drop, nonzero, heap_api, oom)]
+#![feature(core, unsafe_no_drop_flag, filling_drop, nonzero)]
 #![cfg_attr(test, feature(test, str_char))]
 #![deny(warnings)]
 
-extern crate alloc;
 extern crate core;
 #[macro_use] extern crate mac;
 extern crate futf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![feature(core, unsafe_no_drop_flag, filling_drop, nonzero)]
 #![cfg_attr(test, feature(test, str_char))]
-#![deny(warnings)]
+#![cfg_attr(test, deny(warnings))]
 
 extern crate core;
 #[macro_use] extern crate mac;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "unstable", feature(core, nonzero, unsafe_no_drop_flag, filling_drop))]
-#![cfg_attr(test, feature(test, str_char))]
+#![cfg_attr(all(test, feature = "unstable"), feature(test, str_char))]
 #![cfg_attr(test, deny(warnings))]
 
 #[cfg(feature = "unstable")] extern crate core;
@@ -13,7 +13,7 @@
 extern crate futf;
 extern crate encoding;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unstable"))]
 extern crate test;
 
 pub use tendril::{Tendril, ByteTendril, StrTendril, SliceExt, ReadExt, SubtendrilError};

--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -1155,7 +1155,7 @@ impl<'a> From<&'a Tendril<fmt::UTF8>> for String {
 }
 
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unstable"))]
 #[path="bench.rs"]
 mod bench;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(feature = "unstable")] use core::nonzero::NonZero;
 use std::{slice, intrinsics};
 use std::mem;
 
@@ -40,6 +39,8 @@ pub unsafe fn copy_lifetime<'a, S: ?Sized, T: ?Sized + 'a>
                            (_ptr: &'a S, ptr: &T) -> &'a T {
     mem::transmute(ptr)
 }
+
+#[cfg(feature = "unstable")] pub use core::nonzero::NonZero;
 
 #[cfg(not(feature = "unstable"))]
 #[derive(Copy, Clone)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature = "unstable")] use core::nonzero::NonZero;
 use std::{slice, intrinsics};
 use std::mem;
 
@@ -40,3 +41,24 @@ pub unsafe fn copy_lifetime<'a, S: ?Sized, T: ?Sized + 'a>
     mem::transmute(ptr)
 }
 
+#[cfg(not(feature = "unstable"))]
+#[derive(Copy, Clone)]
+pub struct NonZero<T>(T);
+
+#[cfg(not(feature = "unstable"))]
+impl<T> NonZero<T> {
+    pub unsafe fn new(x: T) -> NonZero<T> { NonZero(x) }
+}
+
+#[cfg(not(feature = "unstable"))]
+impl<T> ::std::ops::Deref for NonZero<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T { &self.0 }
+}
+
+#[cfg(not(feature = "unstable"))]
+pub fn is_post_drop(_: usize) -> bool { false }
+
+#[cfg(feature = "unstable")]
+pub fn is_post_drop(x: usize) -> bool { x == mem::POST_DROP_USIZE }


### PR DESCRIPTION
Without the `unstable` Cargo feature, on 64 bit platforms:
* `Tendril<_>` is 17 bytes instead of 16. (It has a drop flag.)
* `Option<Tendril<_>>` is 18 bytes instead of 16. (It has a drop flag and an explicit tag.)

r? @Manishearth

Needed for https://github.com/servo/html5ever/issues/53

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/tendril/14)
<!-- Reviewable:end -->
