### PR TITLE
Update tendril to avoid double borrow.

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -156,7 +156,7 @@ pub unsafe trait SubsetOf<Super>: Format
 
 /// Indicates a format which corresponds to a Rust slice type,
 /// representing exactly the same invariants.
-pub unsafe trait SliceFormat: Format {
+pub unsafe trait SliceFormat: Format + Sized {
     type Slice: ?Sized + Slice<Format = Self>;
 }
 


### PR DESCRIPTION
Update tendril to avoid double borrow. This double borrow is detected by the latest Nightly builds, or at least will be once https://github.com/rust-lang/rust/pull/27641/ makes it into such a build.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/tendril/18)
<!-- Reviewable:end -->
