### PR TITLE
Avoid using the std::intrinsics module

### DIFF
--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{ptr, mem, intrinsics, hash, str, u32, io, slice, cmp};
+use std::{ptr, mem, hash, str, u32, io, slice, cmp};
 use std::sync::atomic::{self, AtomicUsize};
 use std::sync::atomic::Ordering as AtomicOrdering;
 use std::borrow::{Borrow, Cow};
@@ -1013,7 +1013,7 @@ impl<F, A> Tendril<F, A>
             marker: PhantomData,
             refcount_marker: PhantomData,
         };
-        intrinsics::copy_nonoverlapping(x.as_ptr(), &mut t.len as *mut u32 as *mut u8, len);
+        ptr::copy_nonoverlapping(x.as_ptr(), &mut t.len as *mut u32 as *mut u8, len);
         t
     }
 
@@ -1032,7 +1032,7 @@ impl<F, A> Tendril<F, A>
     unsafe fn owned_copy(x: &[u8]) -> Tendril<F, A> {
         let len32 = x.len() as u32;
         let mut b = Buf32::with_capacity(len32, Header::new());
-        intrinsics::copy_nonoverlapping(x.as_ptr(), b.data_ptr(), x.len());
+        ptr::copy_nonoverlapping(x.as_ptr(), b.data_ptr(), x.len());
         b.len = len32;
         Tendril::owned(b)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{slice, intrinsics};
+use std::{slice, ptr};
 use std::mem;
 
 #[inline(always)]
@@ -23,7 +23,7 @@ pub unsafe fn unsafe_slice_mut<'a>(buf: &'a mut [u8], start: usize, new_len: usi
 
 #[inline(always)]
 pub unsafe fn copy_and_advance(dest: &mut *mut u8, src: &[u8]) {
-    intrinsics::copy_nonoverlapping(src.as_ptr(), *dest, src.len());
+    ptr::copy_nonoverlapping(src.as_ptr(), *dest, src.len());
     *dest = dest.offset(src.len() as isize)
 }
 


### PR DESCRIPTION
This is actually unstable but [there's a bug][bug] in the compiler allowing it
to be used. Good news is that these functions are available stable elsewhere!

[bug]: https://github.com/rust-lang/rust/issues/28075

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/tendril/20)
<!-- Reviewable:end -->
