### PR TITLE
Rewrite UTF8Validator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "Compact buffer/string type for zero-copy parsing"
 mac = "0"
 encoding = "0"
 futf = "0.1.1"
-utf-8 = "0.5"
+utf-8 = "0.6"
 
 [dev-dependencies]
 rand = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tendril"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["Keegan McAllister <mcallister.keegan@gmail.com>",
 		   "Simon Sapin <simon.sapin@exyr.org>",
 		   "Chris Morgan <me@chrismorgan.info>"]
@@ -13,6 +13,7 @@ description = "Compact buffer/string type for zero-copy parsing"
 mac = "0"
 encoding = "0"
 futf = "0.1.1"
+utf-8 = "0.5"
 
 [dev-dependencies]
 rand = "0"

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -157,7 +157,7 @@ pub unsafe trait SubsetOf<Super>: Format
 /// Indicates a format which corresponds to a Rust slice type,
 /// representing exactly the same invariants.
 pub unsafe trait SliceFormat: Format + Sized {
-    type Slice: ?Sized + Slice<Format = Self>;
+    type Slice: ?Sized + Slice;
 }
 
 /// Indicates a format which contains characters from Unicode
@@ -181,8 +181,6 @@ pub unsafe trait CharFormat<'a>: Format {
 
 /// Indicates a Rust slice type that has a corresponding format.
 pub unsafe trait Slice {
-    type Format: SliceFormat<Slice = Self>;
-
     /// Access the raw bytes of the slice.
     fn as_bytes(&self) -> &[u8];
 
@@ -217,8 +215,6 @@ unsafe impl SliceFormat for Bytes {
 }
 
 unsafe impl Slice for [u8] {
-    type Format = Bytes;
-
     #[inline(always)]
     fn as_bytes(&self) -> &[u8] {
         self
@@ -329,8 +325,6 @@ unsafe impl SliceFormat for UTF8 {
 }
 
 unsafe impl Slice for str {
-    type Format = UTF8;
-
     #[inline(always)]
     fn as_bytes(&self) -> &[u8] {
         str::as_bytes(self)

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -179,7 +179,7 @@ pub unsafe trait CharFormat<'a>: Format {
         where F: FnOnce(&[u8]);
 }
 
-/// Indicates a Rust slice type that has a corresponding format.
+/// Indicates a Rust slice type that is represented in memory as bytes.
 pub unsafe trait Slice {
     /// Access the raw bytes of the slice.
     fn as_bytes(&self) -> &[u8];

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -191,6 +191,12 @@ pub unsafe trait Slice {
     /// You may assume the buffer is *already validated*
     /// for `Format`.
     unsafe fn from_bytes(x: &[u8]) -> &Self;
+
+    /// Convert a byte slice to this kind of slice.
+    ///
+    /// You may assume the buffer is *already validated*
+    /// for `Format`.
+    unsafe fn from_mut_bytes(x: &mut [u8]) -> &mut Self;
 }
 
 /// Marker type for uninterpreted bytes.
@@ -220,6 +226,11 @@ unsafe impl Slice for [u8] {
 
     #[inline(always)]
     unsafe fn from_bytes(x: &[u8]) -> &[u8] {
+        x
+    }
+
+    #[inline(always)]
+    unsafe fn from_mut_bytes(x: &mut [u8]) -> &mut [u8] {
         x
     }
 }
@@ -328,6 +339,11 @@ unsafe impl Slice for str {
     #[inline(always)]
     unsafe fn from_bytes(x: &[u8]) -> &str {
         str::from_utf8_unchecked(x)
+    }
+
+    #[inline(always)]
+    unsafe fn from_mut_bytes(x: &mut [u8]) -> &mut str {
+        mem::transmute(x)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 #[macro_use] extern crate mac;
 extern crate futf;
 extern crate encoding;
+extern crate utf8;
 
 #[cfg(all(test, feature = "unstable"))]
 extern crate test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 #[cfg(feature = "unstable")] extern crate core;
 #[macro_use] extern crate mac;
 extern crate futf;
-extern crate encoding;
 extern crate utf8;
 
 #[cfg(all(test, feature = "unstable"))]
@@ -24,6 +23,12 @@ pub use stream::TendrilSink;
 
 pub mod fmt;
 pub mod stream;
+
+/// Re-export the rust-encoding crate.
+pub mod encoding {
+    extern crate encoding;
+    pub use self::encoding::*;
+}
 
 mod util;
 mod buf32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ extern crate test;
 pub use tendril::{Tendril, ByteTendril, StrTendril, SliceExt, ReadExt, SubtendrilError};
 pub use tendril::{SendTendril, Atomicity, Atomic, NonAtomic};
 pub use fmt::Format;
+pub use stream::TendrilSink;
 
 pub mod fmt;
 pub mod stream;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -189,12 +189,23 @@ impl<Sink, A> LossyDecoder<Sink, A>
     /// Create a new incremental decoder.
     #[inline]
     pub fn new(encoding: EncodingRef, sink: Sink) -> LossyDecoder<Sink, A> {
-        LossyDecoder {
-            inner: if encoding.name() == "utf-8" {
-                LossyDecoderInner::Utf8(Utf8LossyDecoder::new(sink))
-            } else {
-                LossyDecoderInner::Other(encoding.raw_decoder(), sink)
+        if encoding.name() == "utf-8" {
+            LossyDecoder::utf8(sink)
+        } else {
+            LossyDecoder {
+                inner:  LossyDecoderInner::Other(encoding.raw_decoder(), sink)
             }
+        }
+    }
+
+    /// Create a new incremental decoder for the UTF-8 encoding.
+    ///
+    /// This is useful for content that is known at run-time to be UTF-8
+    /// (whereas `Utf8LossyDecoder` requires knowning at compile-time.)
+    #[inline]
+    pub fn utf8(sink: Sink) -> LossyDecoder<Sink, A> {
+        LossyDecoder {
+            inner: LossyDecoderInner::Utf8(Utf8LossyDecoder::new(sink))
         }
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,7 +6,7 @@
 
 //! Streams of tendrils.
 
-use tendril::{Tendril, Atomicity};
+use tendril::{Tendril, Atomicity, NonAtomic};
 use fmt;
 
 use std::borrow::Cow;
@@ -24,7 +24,7 @@ use utf8;
 /// architecture.
 ///
 /// [html5ever]: https://github.com/servo/html5ever
-pub trait TendrilSink<F, A>
+pub trait TendrilSink<F, A=NonAtomic>
     where F: fmt::Format,
           A: Atomicity,
 {
@@ -91,7 +91,7 @@ pub trait TendrilSink<F, A>
 ///
 /// This does not allocate memory: the output is either subtendrils on the input,
 /// on inline tendrils for a single code point.
-pub struct Utf8LossyDecoder<Sink, A>
+pub struct Utf8LossyDecoder<Sink, A=NonAtomic>
     where Sink: TendrilSink<fmt::UTF8, A>,
           A: Atomicity
 {
@@ -169,7 +169,7 @@ impl<Sink, A> TendrilSink<fmt::Bytes, A> for Utf8LossyDecoder<Sink, A>
 /// and emits Unicode (`StrTendril`).
 ///
 /// This allocates new tendrils for encodings other than UTF-8.
-pub struct LossyDecoder<Sink, A>
+pub struct LossyDecoder<Sink, A=NonAtomic>
     where Sink: TendrilSink<fmt::UTF8, A>,
           A: Atomicity {
     inner: LossyDecoderInner<Sink, A>,

--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -399,6 +399,18 @@ impl<F, A> Deref for Tendril<F, A>
     }
 }
 
+impl<F, A> DerefMut for Tendril<F, A>
+    where F: fmt::SliceFormat,
+          A: Atomicity,
+{
+    #[inline]
+    fn deref_mut(&mut self) -> &mut F::Slice {
+        unsafe {
+            F::Slice::from_mut_bytes(self.as_mut_byte_slice())
+        }
+    }
+}
+
 impl<F, A> Borrow<[u8]> for Tendril<F, A>
     where F: fmt::SliceFormat,
           A: Atomicity,
@@ -1064,15 +1076,11 @@ impl<F, A> Tendril<F, A>
             }
         }
     }
-}
 
-// There's no need to worry about locking on an atomic Tendril, because it makes it unique as
-// soon as you do that.
-impl<A> DerefMut for Tendril<fmt::Bytes, A>
-    where A: Atomicity,
-{
+    // There's no need to worry about locking on an atomic Tendril, because it makes it unique as
+    // soon as you do that.
     #[inline]
-    fn deref_mut<'a>(&'a mut self) -> &'a mut [u8] {
+    fn as_mut_byte_slice<'a>(&'a mut self) -> &'a mut [u8] {
         unsafe {
             match *self.ptr.get() {
                 EMPTY_TAG => &mut [],
@@ -1089,7 +1097,6 @@ impl<A> DerefMut for Tendril<fmt::Bytes, A>
         }
     }
 }
-
 
 impl<F, A> Tendril<F, A>
     where F: fmt::SliceFormat,


### PR DESCRIPTION
* Rename it to `Utf8LossyDecoder`
* Don’t allocate any memory.
* Handles errors per [Unicode Standard §5.22 "Best Practice for U+FFFD Substitution"](http://www.unicode.org/versions/Unicode8.0.0/ch05.pdf#G40630) This matches `String::from_utf8_lossy`.

This introduces two (recursive) dependencies that should probably be reviewed as well:

* [rust-utf8](https://github.com/SimonSapin/rust-utf8)
* [string-wrapper](https://github.com/SimonSapin/rust-std-candidates/tree/master/string-wrapper)

r? @nox

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/tendril/23)
<!-- Reviewable:end -->
