### PR TITLE
Upgrade to rustc 1.10.0-nightly (cda7c1cf2 2016-04-27)

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -16,7 +16,7 @@ fn index_words_string(input: &String) -> HashMap<char, Vec<String>> {
             continue;
         }
         let word = word.to_owned();
-        match index.entry(word.char_at(0)) {
+        match index.entry(word.chars().next().unwrap()) {
             Entry::Occupied(mut e) => {
                 let x: &mut Vec<String> = e.get_mut();
                 x.push(word);
@@ -34,7 +34,7 @@ fn index_words_tendril(input: &StrTendril) -> HashMap<char, Vec<StrTendril>> {
         match t.pop_front_char_run(|c| c != ' ') {
             None => return index,
             Some((_, false)) => (),
-            Some((word, true)) => match index.entry(word.char_at(0)) {
+            Some((word, true)) => match index.entry(word.chars().next().unwrap()) {
                 Entry::Occupied(mut e) => { e.get_mut().push(word); }
                 Entry::Vacant(e) => { e.insert(vec![word]); }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "unstable", feature(nonzero, unsafe_no_drop_flag, filling_drop))]
-#![cfg_attr(all(test, feature = "unstable"), feature(test, str_char))]
+#![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #![cfg_attr(test, deny(warnings))]
 
 #[cfg(feature = "unstable")] extern crate core;

--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -2117,10 +2117,10 @@ mod test {
         let mut t = b"Hello".to_tendril();
         t.extend(None::<&[u8]>.into_iter());
         assert_eq!(b"Hello", &*t);
-        t.extend([b", " as &[u8], b"world" as &[u8], b"!" as &[u8]].iter().map(|&s| s));
+        t.extend([b", ".as_ref(), b"world".as_ref(), b"!".as_ref()].iter().map(|&s| s));
         assert_eq!(b"Hello, world!", &*t);
-        assert_eq!(b"Hello, world!", &*[b"Hello" as &[u8], b", " as &[u8],
-                                        b"world" as &[u8], b"!" as &[u8]]
+        assert_eq!(b"Hello, world!", &*[b"Hello".as_ref(), b", ".as_ref(),
+                                        b"world".as_ref(), b"!".as_ref()]
                                     .iter().map(|&s| s).collect::<ByteTendril>());
 
         let string = "the quick brown fox jumps over the lazy dog";
@@ -2186,13 +2186,13 @@ mod test {
         // https://github.com/rust-lang/rust/issues/27108.
         let mut map = HashMap::new();
         map.insert("foo".to_tendril(), 1);
-        assert_eq!(map.get(b"foo" as &[u8]), Some(&1));
-        assert_eq!(map.get(b"bar" as &[u8]), None);
+        assert_eq!(map.get(b"foo".as_ref()), Some(&1));
+        assert_eq!(map.get(b"bar".as_ref()), None);
 
         let mut map = HashMap::new();
         map.insert(b"foo".to_tendril(), 1);
-        assert_eq!(map.get(b"foo" as &[u8]), Some(&1));
-        assert_eq!(map.get(b"bar" as &[u8]), None);
+        assert_eq!(map.get(b"foo".as_ref()), Some(&1));
+        assert_eq!(map.get(b"bar".as_ref()), None);
     }
 
     #[test]


### PR DESCRIPTION
Fix deprecation warnings and warnings like:

```
src/tendril.rs:2194:28: 2194:43 warning: can't cast this type, #[warn(const_err)] on by default
src/tendril.rs:2194         assert_eq!(map.get(b"foo" as &[u8]), Some(&1));
```

This crate treats all warnings as errors when testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/tendril/26)
<!-- Reviewable:end -->
