### PR TITLE
Use NonZeroUsize from standard library

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -39,19 +39,3 @@ pub unsafe fn copy_lifetime<'a, S: ?Sized, T: ?Sized + 'a>
                            (_ptr: &'a S, ptr: &T) -> &'a T {
     mem::transmute(ptr)
 }
-
-#[derive(Copy, Clone)]
-pub struct NonZeroUsize(&'static u8);
-
-impl NonZeroUsize {
-    #[inline]
-    pub unsafe fn new(value: usize) -> Self {
-        debug_assert!(value != 0);
-        NonZeroUsize(&*(value as *const u8))
-    }
-
-    #[inline]
-    pub fn get(self) -> usize {
-        self.0 as *const u8 as usize
-    }
-}


### PR DESCRIPTION
miri complains about reference hack. Note that there is still ridiculous amount of UB, refer to #41, but may as well start removing it somehow.