### PR TITLE
Bump futf to 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "Compact buffer/string type for zero-copy parsing"
 mac = "0.1"
 encoding = {version = "0.2", optional = true}
 encoding_rs = {version = "0.8.12", optional = true}
-futf = "0.1.2"
+futf = "0.1.5"
 utf-8 = "0.7"
 
 [dev-dependencies]


### PR DESCRIPTION
This is to make tendril compatible with `cargo update -Z minimal-versions`. Continuing from https://github.com/servo/futf/pull/12.