### PR TITLE
Update docs to address Send/Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ shared buffers. When you mutate a tendril, an owned copy is made if necessary.
 Further mutations occur in-place until the string becomes shared, e.g. with
 `clone()` or `subtendril()`.
 
-Buffer sharing is accomplished through thread-local (non-atomic) reference
-counting, which has very low overhead. The Rust type system will prevent
-you at compile time from sending a tendril between threads. (See below
-for thoughts on relaxing this restriction.)
+Buffer sharing is by default accomplished through thread-local (non-atomic)
+reference counting, which has very low overhead. The Rust type system will prevent
+you at compile time from sending a nonatomic tendril between threads. To make a
+tendril shareable across threads, define it with [`Atomic`][Atomic] or use
+[`SendTendril`][SendTendril]
 
 Whereas `String` allocates in the heap for any non-empty string, `Tendril` can
 store small strings (up to 8 bytes) in-line, without a heap allocation.
@@ -88,6 +89,8 @@ metadata is chosen by the API consumer; it defaults to `()`, which has size
 zero. For any non-inline string, we can provide the associated metadata as well
 as a byte offset.
 
+[Atomic]: https://doc.servo.org/tendril/tendril/struct.Atomic.html
+[SendTendril]: https://doc.servo.org/tendril/tendril/struct.SendTendril.html
 [NonZero]: https://doc.rust-lang.org/core/nonzero/struct.NonZero.html
 [html5ever]: https://github.com/servo/html5ever
 [WTF-8]: https://simonsapin.github.io/wtf-8/

--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -159,10 +159,11 @@ pub enum SubtendrilError {
 /// if necessary. Further mutations occur in-place until the string becomes
 /// shared, e.g. with `clone()` or `subtendril()`.
 ///
-/// Buffer sharing is accomplished through thread-local (non-atomic) reference
-/// counting, which has very low overhead. The Rust type system will prevent
-/// you at compile time from sending a `Tendril` between threads. We plan to
-/// relax this restriction in the future; see `README.md`.
+/// Buffer sharing is by default accomplished through thread-local (non-atomic)
+/// reference counting, which has very low overhead. The Rust type system will prevent
+/// you at compile time from sending a nonatomic tendril between threads. To make a
+/// tendril shareable across threads, define it with [`Atomic`][Atomic] or use
+/// [`SendTendril`][SendTendril].
 ///
 /// Whereas `String` allocates in the heap for any non-empty string, `Tendril`
 /// can store small strings (up to 8 bytes) in-line, without a heap allocation.


### PR DESCRIPTION
This crate has had a warning about thread-local (non-atomic) reference sharing for quite a while. It's also had a couple of solutions in place, depending on the use case, for at least a year. This PR updates the documentation accordingly.

TODOs for any reviewers:
- [ ] Ensure what I wrote is correct and complete
- [ ] Catch typos I missed

Fixes #53.